### PR TITLE
21 purl links seems wrong missing slash between site and filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Diagram depicting where this project fits into the pipeline of secure developmen
 activities, the entire sequence is typically cyclical. The end state of SBOM management receives the SBOM files for the product versions to properly
 manage the state of vulnerabilities over time. 
 
-![CycloneDX logo](https://github.com/CycloneDX/cyclonedx-buildroot/blob/process-flow-description/build-Page-2.drawio.png)
+![CycloneDX logo](https://github.com/CycloneDX/cyclonedx-buildroot/blob/main/build-Page-2.drawio.png)
 
 ## CycloneDX Schema Support
 

--- a/generateBuildrootSBOM.py
+++ b/generateBuildrootSBOM.py
@@ -45,9 +45,9 @@ def create_buildroot_sbom(input_file_name: str, cpe_file_name: str, br_bom: Bom)
         for row in sheetX:
             try:
 
-                download_url_value = row['SOURCE SITE'] + "/" + row['SOURCE ARCHIVE']
+                download_url_with_slash = row['SOURCE SITE'] + "/" + row['SOURCE ARCHIVE']
                 purl_info = PackageURL(type='generic', name=row['PACKAGE'], version=row['VERSION'],
-                                       qualifiers={'download_url': download_url_value})
+                                       qualifiers={'download_url': download_url_with_slash})
                 lfac = LicenseFactory()
                 cpe_id_value = "unknown"
                 cpe_id_value = get_cpe_value(cpe_file_name, row['PACKAGE'])


### PR DESCRIPTION
PURL value had a typo missing a necessary slash identified by Peter Korsgaard a Buildroot maintainer.
I found that the diagram at the github repo indicated a broken URL which is corrected.
@CycloneDX/buildroot-maintainers  @jkowalleck 