### PR TITLE
Fix parsing licenses list

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -39,6 +39,10 @@ class TestStringMethods(unittest.TestCase):
         generateBuildrootSBOM.my_main("-c cpe_data_show_pkg_stats.json")
         assert 1
 
+    def test_split_non_parenthesized(self):
+        result = generateBuildrootSBOM._split_non_parenthesized("aaa,bbb(ccc,ddd),eee", ",")
+        assert result == [ 'aaa', 'bbb(ccc,ddd)', 'eee' ]
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The LICENSE field in the manifest.csv contains a comma-separated list of license identifiers, possibly with details in parentheses. If those details also contained a comma, parts of them were incorrectly treated as a separate license. Also, the resulting license identifiers often contained leading whitespace.

Example:

'BSD-4-Clause, LGPL-2.1+ (libblkid, libfdisk, libmount), BSD-3-Clause (libuuid)'

Until now, this resulted in the following license entries:
- 'BSD-4-Clause'
- ' LGPL-2.1+ (libblkid'
- ' libfdisk'
- ' libmount)'
- ' BSD-3-Clause (libuuid)'

But it should be:
- 'BSD-4-Clause'
- 'LPGL-2.1+ (libblkid, libfdisk, libmount)'
- 'BSD-3-Clause (libuuid)'