### PR TITLE
tests: fix python detection for `tox`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ minversion = 4.0
 envlist =
 #    flake8
     mypy-{current,lowest}
-    312,311,310,39,38
+    py{313,312,311,310,39,38}
 #    bandit
 skip_missing_interpreters = True
 usedevelop = False


### PR DESCRIPTION
caused by https://github.com/CycloneDX/cyclonedx-buildroot/pull/74#discussion_r2030076109 ff 

the notation `py{313,312,311,310,39,38}` caused that tox would search for python executables in different versions, and executes the tests with all the versions that were found. here is an example from my setup- i have p3.12 and py3.13 installed.
```shellSession
$ poetry run tox
 mypy-current: OK (3.03=setup[0.01]+cmd[0.01,1.17,0.99,0.84] seconds)
  mypy-lowest: OK (3.10=setup[0.01]+cmd[0.00,1.23,1.01,0.85] seconds)
  py313: OK (16.96=setup[6.07]+cmd[0.00,5.23,0.99,4.66] seconds)
  py312: OK (13.77=setup[4.81]+cmd[0.00,3.58,1.02,4.36] seconds)
  py311: SKIP (0.00 seconds)
  py310: SKIP (0.00 seconds)
  py39: SKIP (0.00 seconds)
  py38: SKIP (0.05 seconds)
  congratulations :) (37.28 seconds)
```

the notation `312,311,310,39,38` causes tox to run the tests with the current py env 5 times, and label each run with a number.
result:
```shellSession
$ poetry run tox
  mypy-current: OK (6.22=setup[0.25]+cmd[0.01,2.73,1.44,1.79] seconds)
  mypy-lowest: OK (9.68=setup[0.11]+cmd[0.00,2.50,1.56,5.50] seconds)
  312: OK (13.50=setup[4.55]+cmd[0.00,3.57,1.02,4.35] seconds)
  311: OK (12.26=setup[3.11]+cmd[0.01,3.68,1.01,4.46] seconds)
  310: OK (13.11=setup[3.23]+cmd[0.00,3.67,1.01,5.19] seconds)
  39: OK (13.53=setup[3.41]+cmd[0.00,3.87,1.18,5.07] seconds)
  38: OK (13.03=setup[3.28]+cmd[0.00,3.83,1.11,4.80] seconds)
  congratulations :) (81.57 seconds)
```

