### PR TITLE
Modify Codacy coverage reporter step for error handling

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -202,12 +202,11 @@ jobs:
           merge-multiple: true
           path: ${{ env.REPORTS_DIR }}
       - name: Run codacy-coverage-reporter
-        env:
-          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
-        ## see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-secrets
-        if: ${{ env.CODACY_PROJECT_TOKEN != '' }}
-        # see https://github.com/codacy/codacy-coverage-reporter-action
-        uses: codacy/codacy-coverage-reporter-action@v1
-        with:
-          project-token: ${{ env.CODACY_PROJECT_TOKEN }}
-          coverage-reports: ${{ env.REPORTS_DIR }}/coverage/*
+      env:
+        CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+      if: ${{ env.CODACY_PROJECT_TOKEN != '' }}
+      uses: codacy/codacy-coverage-reporter-action@v1
+      with:
+        project-token: ${{ env.CODACY_PROJECT_TOKEN }}
+        coverage-reports: ${{ env.REPORTS_DIR }}/coverage/*
+      continue-on-error: true  # Don't fail the workflow if Codacy times out


### PR DESCRIPTION
Added continue-on-error option to Codacy coverage reporter step to prevent workflow failure on timeout.